### PR TITLE
simple home page

### DIFF
--- a/smart-cart/app/views/home/show.html.erb
+++ b/smart-cart/app/views/home/show.html.erb
@@ -1,2 +1,5 @@
+<h1>SmartCart</h1>
 
-<%= @test %>
+<p>The current version supports shoppers within the Waterloo, Ontario region.</p>
+
+<p><%= link_to 'Find me the cheapest groceries', stores_path %></p>


### PR DESCRIPTION
- added simple home page stuff to match the content that is on figma
- no logic in the controller

### testing
- checkout this branch (`emma/homepage`)
- `rails server`
- go to /home in the URL (should appear as follows)
![Screen Shot 2023-01-20 at 12 46 08 PM](https://user-images.githubusercontent.com/65259395/213770527-9b77f193-9eac-4a54-bbaf-83d822f7b5a3.png)
- the hyperlink should go to /stores

