### PR TITLE
fixed adding item to db to add default quantity of 1

### DIFF
--- a/smart-cart/app/controllers/lists_controller.rb
+++ b/smart-cart/app/controllers/lists_controller.rb
@@ -41,7 +41,7 @@ class ListsController < ApplicationController
     #   end
     # end
 
-    List.create(list_id: $session_id, item: params[:item])
+    List.create(list_id: $session_id, item: params[:item], quantity: 1)
 
     if ($list.length >= 1) 
       $list.push(params[:item])


### PR DESCRIPTION
**Summary**
- after emma changed list table, had to fix the method that adds item to db by making it have a default quantity of 1

**Testing**
- go to /lists and use the form to add an item to your list
- check to see that the item was added to the db by checking ur terminal, should see something like this
<img width="1190" alt="image" src="https://user-images.githubusercontent.com/65199704/216743736-b0a2d271-852f-4722-969f-929d692ae5b8.png">
