### PR TITLE
sessions

### DIFF
--- a/smart-cart/app/controllers/home_controller.rb
+++ b/smart-cart/app/controllers/home_controller.rb
@@ -1,5 +1,12 @@
 class HomeController < ApplicationController
     def show
-        @test = "hello world"
+        found_unique_id = false
+        until found_unique_id do
+            new_session_id = rand(100001) # generates a random number between 0-100000
+            if(List.find_by(list_id: new_session_id).blank?)
+                session[:current_user_id] = new_session_id # sets the environment variable
+                found_unique_id = true # breaks the loop
+            end
+        end
     end
 end

--- a/smart-cart/app/controllers/lists_controller.rb
+++ b/smart-cart/app/controllers/lists_controller.rb
@@ -7,7 +7,6 @@ class ListsController < ApplicationController
     # @lists = List.all
     @list = []
     @current_list = $list
-    session[:current_user_id] = 1234567
     $session_id = session[:current_user_id]
   end
 

--- a/smart-cart/app/controllers/lists_controller.rb
+++ b/smart-cart/app/controllers/lists_controller.rb
@@ -41,7 +41,7 @@ class ListsController < ApplicationController
     #   end
     # end
 
-    List.create(list_id: $session_id, item: params[:item])
+    List.create(list_id: $session_id, item: params[:item], quantity: 1)
 
     if ($list.length >= 1) 
       $list.push(params[:item])

--- a/smart-cart/app/controllers/recommendations_controller.rb
+++ b/smart-cart/app/controllers/recommendations_controller.rb
@@ -2,7 +2,6 @@ class RecommendationsController < ApplicationController
     
 
     def show
-        session[:current_user_id] = 1234567
         session_id = session[:current_user_id]
 
         # check if there is already an entry in Recommendations for the current user


### PR DESCRIPTION
## Summary
added logic to generate and set a random number as a user's session id (therefore also their list id)

## How to test
1. go to /home
2. check that the random number is being generated (in my case its 8799):
![Screen Shot 2023-02-03 at 11 22 25 PM](https://user-images.githubusercontent.com/65259395/216748291-3e206c97-1c6d-4bf9-b9ec-6850803ac452.png)
3. go to /lists and add something
4. check that the same random number is being used to add that item to the database
![Screen Shot 2023-02-03 at 11 23 28 PM](https://user-images.githubusercontent.com/65259395/216748323-61f9dfb2-65eb-4327-b3b3-3ec8b3f6d188.png)
5. go to /recommendations
6. check that its the same random number being added to the recs database
![Screen Shot 2023-02-03 at 11 24 28 PM](https://user-images.githubusercontent.com/65259395/216748361-4a144af3-45df-4e67-a357-2abfcc740e20.png)
7. close the tab and reopen it, check that its created a new session id for you

i think those are all the pages right now that actively use the session id, not sure if i missed any others so just let me know if it breaks on other pages


