### PR TITLE
stemming input

### DIFF
--- a/smart-cart/Gemfile
+++ b/smart-cart/Gemfile
@@ -70,3 +70,5 @@ group :test do
   gem "selenium-webdriver"
   gem "webdrivers"
 end
+
+gem "stemmify", "~> 0.0.2"

--- a/smart-cart/Gemfile.lock
+++ b/smart-cart/Gemfile.lock
@@ -180,6 +180,7 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
+    stemmify (0.0.2)
     stimulus-rails (1.2.1)
       railties (>= 6.0.0)
     thor (1.2.1)
@@ -222,6 +223,7 @@ DEPENDENCIES
   rails (~> 7.0.4, >= 7.0.4.2)
   selenium-webdriver
   sprockets-rails
+  stemmify (~> 0.0.2)
   stimulus-rails
   turbo-rails
   tzinfo-data
@@ -232,4 +234,4 @@ RUBY VERSION
    ruby 3.0.1p64
 
 BUNDLED WITH
-   2.4.4
+   2.4.7

--- a/smart-cart/app/controllers/lists_controller.rb
+++ b/smart-cart/app/controllers/lists_controller.rb
@@ -49,17 +49,22 @@ class ListsController < ApplicationController
       stemmed_tokens.append(t.stem) # stems each token: ["granny", "smith", "apples"] -> ["granni", "smith", "appl"]
     end
     stemmed_item = stemmed_tokens * " " # joins each token into a single string: ["granni", "smith", "appl"] -> "granni smith appl"
-    print stemmed_item
 
-    @list = List.create(list_id: $session_id, item: params[:item], quantity: 1)
+    if (!List.find_by(list_id: $session_id, stemmed_item: stemmed_item).blank?)
+      redirect_to lists_path, notice: 'You already have that item on your list! Please add something else.'
+    else
+      @list = List.create(list_id: $session_id, item: params[:item], quantity: 1, stemmed_item: stemmed_item)
 
-    if ($list.length >= 1) 
-      $list.push(params[:item])
-      redirect_to lists_path, notice: 'List was successfully updated.'
-    else 
-      $list.push(params[:item]) 
-      redirect_to lists_path, notice: 'List was successfully created.'
+      if ($list.length >= 1) 
+        $list.push(params[:item])
+        redirect_to lists_path, notice: 'List was successfully updated.'
+      else 
+        $list.push(params[:item]) 
+        redirect_to lists_path, notice: 'List was successfully created.'
+      end
     end
+
+    
 
     # @list = List.new(params.require(:list).permit(:item))
 

--- a/smart-cart/app/controllers/lists_controller.rb
+++ b/smart-cart/app/controllers/lists_controller.rb
@@ -40,6 +40,16 @@ class ListsController < ApplicationController
     #     format.json { render json: @list.errors, status: :unprocessable_entity }
     #   end
     # end
+   
+    raw_item = params[:item]
+    text_item = raw_item.gsub(/[^0-9a-z ]/i, '') # removes special characters
+    raw_tokens = text_item.split # breaks at every space, returns an array: granny smith apples -> ["granny", "smith", "apples"]
+    stemmed_tokens = []
+    for t in raw_tokens
+      stemmed_tokens.append(t.stem) # stems each token: ["granny", "smith", "apples"] -> ["granni", "smith", "appl"]
+    end
+    stemmed_item = stemmed_tokens * " " # joins each token into a single string: ["granni", "smith", "appl"] -> "granni smith appl"
+    print stemmed_item
 
     @list = List.create(list_id: $session_id, item: params[:item], quantity: 1)
 

--- a/smart-cart/db/migrate/20230224012114_add_stemmed_item_to_lists.rb
+++ b/smart-cart/db/migrate/20230224012114_add_stemmed_item_to_lists.rb
@@ -1,0 +1,5 @@
+class AddStemmedItemToLists < ActiveRecord::Migration[7.0]
+  def change
+    add_column :lists, :stemmed_item, :string
+  end
+end

--- a/smart-cart/db/schema.rb
+++ b/smart-cart/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_09_222909) do
+ActiveRecord::Schema[7.0].define(version: 2023_02_24_012114) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -20,6 +20,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_09_222909) do
     t.integer "quantity"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "stemmed_item"
   end
 
   create_table "recommendations", force: :cascade do |t|


### PR DESCRIPTION
## summary
- special characters are removed from item: **"granny smith, apple" -> "granny smith apple"**
    - (if someone makes a mistake like "granny%smith%apple", this becomes "grannysmithapple")
- the item is tokenized with space as the delimiter: **"granny smith apple" -> ["granny", "smith", "apple"]**
- each token is stemmed using the `stemmify` gem (implements Porter Stemmer): **["granny", "smith", "apples"] -> ["granni", "smith", "appl"]**
- tokens are joined together again using white space: **["granni", "smith", "appl"] -> "granni smith appl"**
- this is saved as `stemmed_item` in the db (I added a new column to Lists)

so now when someone adds "apples" after already having added "apple", we check if there exists an entry in the Lists table where session_id is the current user AND the stemmed version (appl) exists. if not, we can add it to the table

## testing
will need to `rake db:migrate` and `bundle install` before testing to make sure that you have stemmify and the new db column