### PR TITLE
added sale end dates and data freshness

### DIFF
--- a/smart-cart/app/controllers/recommendations_controller.rb
+++ b/smart-cart/app/controllers/recommendations_controller.rb
@@ -75,6 +75,8 @@ class RecommendationsController < ApplicationController
         $prices = []
         $is_sale = []
         $stores = []
+        $sale_dates = []
+        $last_data_refresh = []
         $current_recommendation.rec.each do |key, value|
             if (key == "full_product_text")
                 $products = value
@@ -86,6 +88,10 @@ class RecommendationsController < ApplicationController
                 $list = value
             elsif (key == "store")
                 $stores = value
+            elsif (key == "sale_valid_until")
+                $sale_dates = value
+            elsif (key == "data_last_refreshed_at")
+                $last_data_refresh = value
             end
         end
     end

--- a/smart-cart/app/views/recommendations/number.html.erb
+++ b/smart-cart/app/views/recommendations/number.html.erb
@@ -5,6 +5,9 @@
 <p> here is your list: </p>
 <%= $list %>
 
+<p> this data was last refreshed at: </p>
+<%= $last_data_refresh[0] %>
+
 <p> here is your recommendation: </p>
 <table>
 <tbody>
@@ -37,7 +40,11 @@
             <% if ($is_sale[x].nil?) %>
                 <td>not available sorry</td>
             <% else %>
-                <td><%= $is_sale[x] %> </td>
+                <% if ($is_sale[x] == true) %>
+                    <td><%= $is_sale[x] %>, until <%= $sale_dates[x] %></td>
+                <% else %>
+                    <td><%= $is_sale[x] %></td>
+                <% end %>
             <% end %>
             <td><%= $stores[x] %> </td>
         <% end %>


### PR DESCRIPTION
![sale valid until and data date](https://user-images.githubusercontent.com/65259395/221311172-24ee7748-b037-401d-aa4a-89c0cf28b64f.png)
dont mind that the result is a little questionable LOL
- if an item is on sale, then we also provide when the sale price is valid until
- now also presents when this data was last scraped at